### PR TITLE
Add docs on permissions. Prefix rolebinding name with namespace

### DIFF
--- a/operator-installer/README.adoc
+++ b/operator-installer/README.adoc
@@ -11,6 +11,32 @@ This document explains how to use the Operator installer (deployment script).
 oc login --server=https://your.ip.address.here:8443 -u developer -p developer
 ```
 
+### Required Permissions
+
+To successfully deploy CodeReady Workspaces using this script, cluster-admin privileges are required. The table below lists objects and required permissions:
+
+[%autowidth]
+|===
+| *Kind*             | *Name*                          | *Description*                                                    | *Permissions*
+| CRD                |                                 | Custom Resource definition - CheCluster                          | cluster-admin
+| CR                 | codeready                       | Custom Resource of CheCluster Kind                               | cluster-admin. Alternatively, a clusterrole can be created
+| ServiceAccount     | codeready-operator              | Operator uses this SA to reconcile CRW objects                   | edit role in a target namespace
+| Role               | codeready-operator              | Scope of permissions for operator service account                | cluster-admin
+| RoleBinding        | codeready-operator              | Assign role to service account                                   | edit role in a target namespace
+| Deployment         | codeready-operator              | Deployment with operator image in template spec                  | edit role in a target namespace
+| ClusterRole        | codeready-operator              | ClusterRole that lets create, update, delete oAuthClients        | cluster-admin
+| ClusterRoleBinding | ${NAMESPACE}-codeready-operator | ClusterRoleBinding that lets create, update, delete oAuthClients | cluster-admin
+| Role               | secret-reader                   | Role that lets read secrets in router namespace                  | cluster-admin
+| RoleBinding        | ${NAMESPACE}-codeready-operator | RoleBinding that lets read secrets in router namespace           | cluster-admin
+|===
+
+By default, operator service account gets privileges to list, get, watch, create, update and delete ingresses, routes, service accounts, roles,
+rolebindings, pvcs, deployments, configmaps, secrets, as well as run execs into pods, watch events and read pod logs in a target namespace.
+
+With self signed certificates support enabled, the operator service account will get privileges to read secrets in an OpenShift router namespace.
+
+With OpenShift oAuth enabled, the operator service account will get privileges to get, list, create, update and delete oAuthclients at a cluster scope.
+
 ### Quickstart
 
 The simplest way to run the script is to use all the defaults.

--- a/operator-installer/deploy.sh
+++ b/operator-installer/deploy.sh
@@ -292,10 +292,11 @@ fi
     else
       printInfo "Role secret-reader already exists"
     fi
-    ${OC_BINARY} get rolebinding codeready-operator -n=${ROUTER_NAMESPACE} > /dev/null 2>&1
+    printInfo "Creating role binding to let operator get secrets in namespace ${ROUTER_NAMESPACE}"
+    ${OC_BINARY} get rolebinding ${OPENSHIFT_PROJECT}-codeready-operator -n=${ROUTER_NAMESPACE} > /dev/null 2>&1
     OUT=$?
     if [ ${OUT} -ne 0 ]; then
-      ${OC_BINARY} create rolebinding codeready-operator --role=secret-reader --serviceaccount=${OPENSHIFT_PROJECT}:codeready-operator -n=${ROUTER_NAMESPACE} > /dev/null
+      ${OC_BINARY} create rolebinding ${OPENSHIFT_PROJECT}-codeready-operator --role=secret-reader --serviceaccount=${OPENSHIFT_PROJECT}:codeready-operator -n=${ROUTER_NAMESPACE} > /dev/null
       OUT=$?
       if [ ${OUT} -ne 0 ]; then
         printWarning "Failed to create rolebinding for secret reader role"
@@ -320,10 +321,10 @@ fi
       printInfo "Cluster role already exists"
     fi
     printInfo "Creating cluster role binding to let operator service account create oAuthClients"
-    ${OC_BINARY} get clusterrolebinding codeready-operator > /dev/null 2>&1
+    ${OC_BINARY} get clusterrolebinding ${OPENSHIFT_PROJECT}-codeready-operator > /dev/null 2>&1
     OUT=$?
     if [ ${OUT} -ne 0 ]; then
-      ${OC_BINARY} create clusterrolebinding codeready-operator --clusterrole=codeready-operator --serviceaccount=${OPENSHIFT_PROJECT}:codeready-operator > /dev/null
+      ${OC_BINARY} create clusterrolebinding ${OPENSHIFT_PROJECT}-codeready-operator --clusterrole=codeready-operator --serviceaccount=${OPENSHIFT_PROJECT}:codeready-operator > /dev/null
       OUT=$?
       if [ ${OUT} -ne 0 ]; then
         printError "Failed to create cluster RoleBinding"


### PR DESCRIPTION
This PR adds docs about objects the deployment script creates and permissions operator service account gets.

It also prefixes roilebinding names with a namespace to make it possible to deploy several instances of CRW that should not share one rolebinding.