### PR TITLE
CRW-273 ensure that path to...

### DIFF
--- a/operator-installer/deploy.sh
+++ b/operator-installer/deploy.sh
@@ -512,7 +512,7 @@ createCustomResource() {
     printWarning "Custom resource codeready aleady exists. If you want the installer to create a CR, delete an existing one:"
     printWarning "${OC_BINARY} delete checlusters/codeready -n ${OPENSHIFT_PROJECT}"
   fi
-  ${OC_BINARY} process -f ${BASE_DIR}/custom-resource.yaml \
+  ${OC_BINARY} process -f "${BASE_DIR}/custom-resource.yaml" \
                -p SERVER_IMAGE_NAME=${SERVER_IMAGE_NAME} \
                -p SERVER_IMAGE_TAG=${SERVER_IMAGE_TAG} \
                -p TLS_SUPPORT=${TLS_SUPPORT} \


### PR DESCRIPTION
CRW-273 ensure that path to BASE_DIR/custom-resource.yaml is OK to include spaces (wrap with quotes)

Change-Id: I90d4f1e210d8c008a3b5755f0febb5dffc2d4213
Signed-off-by: nickboldt <nboldt@redhat.com>