### PR TITLE
CRW-351 create a secret after deploying operator

### DIFF
--- a/operator-installer/migrate_1.1_to_1.2.sh
+++ b/operator-installer/migrate_1.1_to_1.2.sh
@@ -228,7 +228,8 @@ isLoggedIn() {
 # check if we already have a name=registryredhatio or type=kubernetes.io/dockerconfigjson secret
 checkAuthenticationWithRegistryRedhatIo()
 {
-  if [[ "$(oc get secret registryredhatio 2>&1)" == *"No resources found"* ]] || \
+  getsecret="$(oc get secret registryredhatio 2>&1)"
+  if [[ "${getsecret}" == *"No resources found"* ]] || [[ "${getsecret}" == *"NotFound"* ]] || \
      [[ "$(oc get secret --field-selector='type=kubernetes.io/dockerconfigjson' 2>&1)" == *"No resources found"* ]]; then
     echo "You must authenticate with registry.redhat.io in order for this script to proceed.
 


### PR DESCRIPTION
CRW-351 create a secret after deploying the operator, then scale it down/up to ensure a new pod is used; add notes about using ~/.docker/config.json default and how to remove the secret if desired

Change-Id: I5953eda53fa692495b40da7559d2d0900263dbb6
Signed-off-by: nickboldt <nboldt@redhat.com>