### PR TITLE
CRW-361 wrong branch - use operator yaml...

### DIFF
--- a/operator-installer/pom.xml
+++ b/operator-installer/pom.xml
@@ -27,7 +27,7 @@
     <name>CodeReady Workspaces :: Operator Installer</name>
     <properties>
         <!-- TODO: switch to 1.x branch, or a tag -->
-        <cheOperatorBranchOrTag>master</cheOperatorBranchOrTag>
+        <cheOperatorBranchOrTag>1.x</cheOperatorBranchOrTag>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
CRW-361 wrong branch - use operator yaml from 1.x for Che 6.19.x / CRW 1.2.x

Change-Id: Ic75f991488e062c6bbe2157f9ca12f1de9a4589b
Signed-off-by: nickboldt <nboldt@redhat.com>