### PR TITLE
CRW-367 add missing deps to npm install so...

### DIFF
--- a/stacks/dependencies/golang/pom.xml
+++ b/stacks/dependencies/golang/pom.xml
@@ -21,14 +21,16 @@
     </parent>
     <groupId>com.redhat</groupId>
     <artifactId>codeready-workspaces-stacks-language-servers-dependencies-golang</artifactId>
-    <version>1.2.0.GA-SNAPSHOT</version>
+    <version>1.2.2.GA-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>CodeReady Workspaces :: Stacks :: Language Servers :: Golang Dependencies</name>
     <properties>
         <GOLANG_IMAGE_VERSION>golang:1.11</GOLANG_IMAGE_VERSION>
+        <GOLANG_LS_OLD_DEPS>console-stamp@0.2.9 strip-ansi@5.2.0 has-ansi@4.0.0 ansi-regex@4.1.0 chalk@2.4.2 escape-string-regexp@2.0.0 ansi-styles@4.1.0 supports-color@7.0.0</GOLANG_LS_OLD_DEPS>
         <GOLANG_LS_VERSION>0.1.7</GOLANG_LS_VERSION>
         <!-- find latest version: https://hub.docker.com/_/node/?tab=description -->
-        <NODEJS_IMAGE_VERSION>node:8.12-alpine</NODEJS_IMAGE_VERSION>
+        <!-- <NODEJS_IMAGE_VERSION>node:10.16-alpine</NODEJS_IMAGE_VERSION> -->
+        <NODEJS_IMAGE_VERSION>node:8.16-alpine</NODEJS_IMAGE_VERSION>
     </properties>
     <build>
         <plugins>
@@ -83,7 +85,7 @@
                                 <!--get LS itself as npm module-->
                                 <mkdir dir="${basedir}/target" />
                                 <exec dir="${basedir}" executable="docker" failonerror="true">
-                                    <arg line="run -v ${basedir}/target:/node_modules ${NODEJS_IMAGE_VERSION} sh -c 'npm install --prefix /node_modules go-language-server@${GOLANG_LS_VERSION}; chmod -R 777 /node_modules'" />
+                                    <arg line="run -v ${basedir}/target:/node_modules ${NODEJS_IMAGE_VERSION} sh -c 'npm install --prefix /node_modules ${GOLANG_LS_OLD_DEPS} go-language-server@${GOLANG_LS_VERSION}; chmod -R 777 /node_modules'" />
                                 </exec>
                                 <!--go get LS go deps-->
                                 <mkdir dir="${basedir}/target/go" />


### PR DESCRIPTION
CRW-367 add missing deps to npm install so that go-language-server can execute postinstall scripts from console-stamp dependency

Change-Id: I7f992216360169a599dbb84b8eb3e60b1f13e50d
Signed-off-by: nickboldt <nboldt@redhat.com>