### PR TITLE
CRW-375 break out of 'oc logs -f' when we...

### DIFF
--- a/operator-installer/deploy.sh
+++ b/operator-installer/deploy.sh
@@ -594,7 +594,15 @@ createCustomResource() {
     printInfo "Waiting for CodeReady Workspaces to boot. Timeout: ${DEPLOYMENT_TIMEOUT_SEC} seconds."
     if [ "${FOLLOW_LOGS}" == "true" ]; then
       printInfo "You may exit this script as soon as the log reports a successful CodeReady Workspaces deployment."
-      ${OC_BINARY} logs -f deployment/codeready-operator -n="${OPENSHIFT_PROJECT}"
+      ${OC_BINARY} logs -f deployment/codeready-operator -n="${OPENSHIFT_PROJECT}" | 
+      {
+        while read i; do
+          echo $i
+          if [[ "$i" == *"CodeReady Workspaces is now available at:"* ]]; then
+            break
+          fi
+        done
+      }
     else
       DESIRED_STATE="Available"
       CURRENT_STATE=$(${OC_BINARY} get checluster/codeready -n="${OPENSHIFT_PROJECT}" -o=jsonpath='{.status.cheClusterRunning}')


### PR DESCRIPTION
CRW-375 break out of 'oc logs -f' when we see 'CodeReady Workspaces is now available at:' line

Change-Id: I02855bea8251d017b1e2ea3bff4b26120780a0db
Signed-off-by: nickboldt <nboldt@redhat.com>