### PR TITLE
Use ubi8/php-73 for getting xdebug files

### DIFF
--- a/stacks/dependencies/php/xdebug.Dockerfile
+++ b/stacks/dependencies/php/xdebug.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-72
-FROM registry.access.redhat.com/ubi8/php-72 as builder
+FROM registry.access.redhat.com/ubi8/php-73 as builder
 USER root
 COPY xdebug.install.sh /tmp/
 RUN /tmp/xdebug.install.sh


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Use **ubi8/php-73** instead of **ubi8/php-72** for getting xdebug files

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-723

cc @nickboldt 
