### PR TITLE
multi-arch support

### DIFF
--- a/stacks/dependencies/golang/pom.xml
+++ b/stacks/dependencies/golang/pom.xml
@@ -53,7 +53,7 @@
                         <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
                     </descriptors>
                     <tarLongFileMode>posix</tarLongFileMode>
-                    <finalName>${project.artifactId}</finalName>
+                    <finalName>${project.artifactId}-${os.arch}</finalName>
                 </configuration>
             </plugin>
             <plugin>

--- a/stacks/dependencies/node10/pom.xml
+++ b/stacks/dependencies/node10/pom.xml
@@ -54,7 +54,7 @@
                         <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
                     </descriptors>
                     <tarLongFileMode>posix</tarLongFileMode>
-                    <finalName>${project.artifactId}</finalName>
+                    <finalName>${project.artifactId}-${os.arch}</finalName>
                 </configuration>
             </plugin>
             <plugin>

--- a/stacks/dependencies/php/php-ls.Dockerfile
+++ b/stacks/dependencies/php/php-ls.Dockerfile
@@ -1,0 +1,16 @@
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-72
+FROM registry.access.redhat.com/ubi8/php-73 as builder
+USER root
+COPY php-ls.install.sh /tmp/
+RUN /tmp/php-ls.install.sh

--- a/stacks/dependencies/php/php-ls.install.sh
+++ b/stacks/dependencies/php/php-ls.install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#!# install php-ls (requires internet access, running as root in a container; cannot run in Brew)
+
+mkdir -p /php
+cd /php
+chmod -R 777 /php
+wget https://getcomposer.org/installer -O /tmp/composer-installer.php
+php /tmp/composer-installer.php --filename=composer --install-dir=/usr/local/bin

--- a/stacks/dependencies/php/pom.xml
+++ b/stacks/dependencies/php/pom.xml
@@ -26,7 +26,7 @@
     <name>CodeReady Workspaces :: Stacks :: Language Servers :: PHP Dependencies</name>
     <properties>
         <PHP_LS_VERSION>5.4.6</PHP_LS_VERSION>
-        <WEBDEVOPS_IMAGE>webdevops/php-apache-dev:alpine-php7</WEBDEVOPS_IMAGE>
+        <PHP_LS_IMAGE>php-ls:tmp</PHP_LS_IMAGE>
         <XDEBUG_BUILDER_IMAGE>php-xdebug:tmp</XDEBUG_BUILDER_IMAGE>
     </properties>
     <build>
@@ -47,7 +47,7 @@
                                 <descriptor>${project.basedir}/src/assembly/assembly-xdebug.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>${project.artifactId}-xdebug</finalName>
+                            <finalName>${project.artifactId}-xdebug-${os.arch}</finalName>
                         </configuration>
                     </execution>
                     <execution>
@@ -62,7 +62,7 @@
                                 <descriptor>${project.basedir}/src/assembly/assembly-ls.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
-                            <finalName>${project.artifactId}</finalName>
+                            <finalName>${project.artifactId}-${os.arch}</finalName>
                         </configuration>
                     </execution>
                 </executions>
@@ -113,7 +113,10 @@
                                 <mkdir dir="${basedir}/target/php-ls" />
                                 <!-- collect lang server stuff - TODO are these still required? -->
                                 <exec dir="${basedir}" executable="docker" failonerror="true">
-                                    <arg line="run -v ${basedir}/target/php-ls:/php ${WEBDEVOPS_IMAGE} sh -c 'mkdir -p /php; cd /php; chmod -R 777 /php; su -l application -c &quot;cd /php; /usr/local/bin/composer require jetbrains/phpstorm-stubs:dev-master; /usr/local/bin/composer require felixfbecker/language-server:${PHP_LS_VERSION}; /usr/local/bin/composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs; mv vendor/* .; rm -rf vendor&quot;; cp /usr/local/bin/composer /php/composer; chmod -R 777 /php'" />
+                                    <arg line="build . -t ${PHP_LS_IMAGE} -f php-ls.Dockerfile" />
+                                </exec>
+                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                    <arg line="run -v ${basedir}/target/php-ls:/php ${PHP_LS_IMAGE} sh -c 'cd /php; /usr/local/bin/composer require jetbrains/phpstorm-stubs:dev-master; /usr/local/bin/composer require felixfbecker/language-server:${PHP_LS_VERSION}; /usr/local/bin/composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs; mv vendor/* .; rm -rf vendor; cp /usr/local/bin/composer /php/composer; chmod -R 777 /php/*'" />
                                 </exec>
                             </target>
                         </configuration>
@@ -128,7 +131,7 @@
                         <configuration>
                             <target>
                                 <exec dir="${basedir}" executable="docker" failonerror="true">
-                                    <arg line="rmi -f ${XDEBUG_BUILDER_IMAGE} ${WEBDEVOPS_IMAGE}" />
+                                    <arg line="rmi -f ${XDEBUG_BUILDER_IMAGE} ${PHP_LS_IMAGE}" />
                                 </exec>
                             </target>
                         </configuration>

--- a/stacks/dependencies/python/pom.xml
+++ b/stacks/dependencies/python/pom.xml
@@ -48,7 +48,7 @@
                         <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
                     </descriptors>
                     <tarLongFileMode>posix</tarLongFileMode>
-                    <finalName>${project.artifactId}</finalName>
+                    <finalName>${project.artifactId}-${os.arch}</finalName>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

Rename artifacts produced to include arch.  Also, removes dependency on webdevops/php-apache-dev:alpine-php7 (currently x86 only) image by using ubi8/php-73 and installing composer inside of it.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
