### PR TITLE
Upgrade to Python 3.8 and add pylint

### DIFF
--- a/python/build.sh
+++ b/python/build.sh
@@ -12,8 +12,8 @@
 #
 
 export SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
-export PYTHON_LS_VERSION=0.21.5
-export PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-36:1"
+export PYTHON_LS_VERSION=0.36.1
+export PYTHON_IMAGE="registry.access.redhat.com/ubi8/python-38:1"
 
 cd $SCRIPT_DIR
 [[ -e target ]] && rm -Rf target
@@ -35,7 +35,7 @@ fi
 
 ${PODMAN} run --rm -v $SCRIPT_DIR/target/python-ls:/python -u root ${PYTHON_IMAGE} sh -c "
     pip install --upgrade pip
-    pip install python-language-server[all]==${PYTHON_LS_VERSION} --prefix=/python
+    pip install python-language-server[all]==${PYTHON_LS_VERSION} ptvsd jedi pylint --prefix=/python
     chmod -R 777 /python
     "
 tar -czf target/codeready-workspaces-stacks-language-servers-dependencies-python-$(uname -m).tar.gz -C target/python-ls .


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

### What does this PR do?
Updates the python depedency stack to use python 3.8, as well as install pylint and other tools needed for the latest version of the python language server.

### What issues does this PR fix or reference?

Part of: CRW-1235, CRW-962, and CRW-1463.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
