### PR TITLE
Fix folder path to copy go deps

### DIFF
--- a/golang/build.sh
+++ b/golang/build.sh
@@ -35,7 +35,7 @@ if [[ ! -x $PODMAN ]]; then
 fi
 
 # go get LS go deps
-${PODMAN} run --rm -v $SCRIPT_DIR/target/go:/go -u root ${GOLANG_IMAGE} sh -c "
+${PODMAN} run --rm -v $SCRIPT_DIR/target/go:/opt/app-root/src/go -u root ${GOLANG_IMAGE} sh -c "
     go get -v github.com/stamblerre/gocode;
     go get -v github.com/uudashr/gopkgs/cmd/gopkgs;
     go get -v github.com/ramya-rao-a/go-outline;
@@ -62,6 +62,6 @@ ${PODMAN} run --rm -v $SCRIPT_DIR/target/go:/go -u root ${GOLANG_IMAGE} sh -c "
     wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANG_LINT_VERSION}
     chmod -R 777 /go
     "
-tar -czf target/codeready-workspaces-stacks-language-servers-dependencies-golang-$(uname -m).tar.gz -C target go node_modules
+tar -czf target/codeready-workspaces-stacks-language-servers-dependencies-golang-$(uname -m).tar.gz -C target go
 
 ${PODMAN} rmi -f ${GOLANG_IMAGE}


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
- Fixes the path to the folder with go dependencies for builder image
- Remove unnecessary  command to copy `node_modules` folder (it doesn't exist anymore)

### What issues does this PR fix or reference?
The problem has come from the [changes](https://github.com/redhat-developer/codeready-workspaces-deprecated/commit/5faa814bc63c3810a00c93ad2413e0335ca4dcd9#diff-eaef4946f96c7330f6581c8dc36867f80fbbe5a91c25657ddbf146a67635021cL16)  where  Go builder image was changed to `registry.access.redhat.com/ubi8/go-toolset:1.14.7-15`. In this image GOPATH is not set, it means that by default all dependencies are downloaded into `/opt/app-root/src/go` folder.
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
