### PR TITLE
chore: update builder image from 1-17 to 1-28 for PHP

### DIFF
--- a/php/php-ls.Dockerfile
+++ b/php/php-ls.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-74
-FROM registry.access.redhat.com/ubi8/php-74:1-17.1614874881 as builder
+FROM registry.access.redhat.com/ubi8/php-74:1-28 as builder
 USER root
 RUN mkdir -p /php && cd /php && chmod -R 777 /php && \
     wget https://getcomposer.org/installer -O /tmp/composer-installer.php && \

--- a/php/xdebug.Dockerfile
+++ b/php/xdebug.Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/php-74
-FROM registry.access.redhat.com/ubi8/php-74:1-17.1614874881 as builder
+FROM registry.access.redhat.com/ubi8/php-74:1-28 as builder
 USER root
 RUN dnf install -y diffutils findutils php-fpm php-opcache php-devel php-pear php-gd php-mysqli php-zlib php-curl ca-certificates && \
     pecl channel-update pecl.php.net && \


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates the builder image for PHP

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1830
